### PR TITLE
Fix: Enable 'prod' build configuration 

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -10,6 +10,9 @@
 [context.develop] # develop branch name
   command = "yarn integ"
 
+[context.master] # master branch name - our production
+  command = "yarn prod"
+
 [context.branch-deploy] # all development branches: feat/fix branches ...
   command = "yarn integ"
 


### PR DESCRIPTION
because web ui Netlify configuration is now branch agnostic.

It fixes Netlify's build on gh-pages branch

This commit will have to be "cherry-pick" to `develop`branch then.